### PR TITLE
fix: dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is the code repository for autogosling's webtool, consisting of the flask b
 
 3. Get a GPT API key [here](https://platform.openai.com/account/api-keys)
 
-After getting the key, store in a .env file at the flask directory.
+After getting the key, store in a .env file at the flask directory. If you don't have an OpenAI key, you can still run the app, you just won't have the NLP input features. 
 
 ```.env
 #.env
@@ -33,64 +33,39 @@ OPENAI_API_KEY=<paste your key here>
 ```
 
 4. Create a conda environment
+
+Installation has been tested with Python 3.12. 
 ```bash
   cd ..
-  conda create --name autogosling --file requirements.txt
+  conda env create --file environment.yaml
   conda activate autogosling
 ```
 
-5. Start the app with script at project root
+5. Go to the `frontend` directory and install the dependencies
+
+```bash
+  cd frontend
+  yarn
+```
+
+6. Start the app with script at project root
 
 ```bash
 chmod 777 autogosling.sh
 ./autogosling.sh
 ```
-The front end of the app automatically runs on port 3000 with the backend on port 7777.
+The front end of the app automatically runs on port 3000 with the backend on port 7777. 
+The first time you run the app, it will take a few minutes for it to start up. 
 
 ### Python Web-App Tar
 
-1. Download the AutoGosling Python web-app [here](https://drive.google.com/file/d/1mAjrZMpZe2nAPcGiRd9KpguJvzWLKvGm/view?usp=share_link).
+If you don't want to clone the github repository, you can also download a tar file of the python web-app instead [here](https://drive.google.com/file/d/1mAjrZMpZe2nAPcGiRd9KpguJvzWLKvGm/view?usp=share_link).
 
 ```bash
   wget -O autogosling.tar.gz  https://drive.google.com/file/d/1mAjrZMpZe2nAPcGiRd9KpguJvzWLKvGm/view?usp=share_link
   tar -xvf autogosling.tar.gz
 ```
 
-2. Go to the project directory
-
-```bash
-  cd autogosling
-```
-
-3. Create a conda environment
-
-```bash
-  conda create --name autogosling --file requirements.txt
-  conda activate autogosling
-```
-4. Download AutoGosling Yolo v7 pre-trained weights [here](https://drive.google.com/file/d/1x_e4V9LDgjsZhMWCnONbiQXK4Zfw6t27/view?usp=share_link):
-
-```bash
-  wget -O best.onnx https://drive.google.com/file/d/1x_e4V9LDgjsZhMWCnONbiQXK4Zfw6t27/view?usp=share_link
-```
-
-
-4. Get a GPT API key [here](https://platform.openai.com/account/api-keys)
-
-After getting the key, store in a .env file at project root directory.
-
-```.env
-#.env
-OPENAI_API_KEY=<paste your key here>
-```
-
-5. Run the app:
-
-```bash
-  python main.py
-```
-
-The app automatically runs on port 7777.
 
 ## Supplementary Files
 

--- a/flask/environment.yaml
+++ b/flask/environment.yaml
@@ -1,0 +1,14 @@
+name: autogosling
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - numpy=1.26.4
+  - onnxruntime=1.17
+  - flask=3.0.2
+  - flask-cors=4.0.0
+  - pillow=10.2.0
+  - opencv=4.9.0
+  - requests=2.31.0
+  - openai=1.12.0
+  - python-dotenv=1.0.1

--- a/flask/yolov7_demo.py
+++ b/flask/yolov7_demo.py
@@ -13,9 +13,9 @@ This notebook generates a gradio app (https://www.gradio.app/) to test the finet
 This notebook is adapted from https://github.com/WongKinYiu/yolov7/blob/main/tools/YOLOv7onnx.ipynb.
 """
 import sys
-import torch
+# import torch
 print(f"Python version: {sys.version}, {sys.version_info} ")
-print(f"Pytorch version: {torch.__version__} ")
+# print(f"Pytorch version: {torch.__version__} ")
 
 # Inference for ONNX model
 import cv2
@@ -144,7 +144,7 @@ def draw_bounding_boxes(im: PIL.Image, bboxes: np.ndarray, classes: np.ndarray,
 #   bboxes, scores = predict(img)
 #   return draw_bounding_boxes(Image.fromarray(img),bboxes,classes,scores)
 
-import gradio as gr
-if __name__ == "__main__":
-    interface = gr.Interface(predict,inputs="image",outputs=["image","image"])
-    interface.launch(share=True,debug=True)
+# import gradio as gr
+# if __name__ == "__main__":
+#     interface = gr.Interface(predict,inputs="image",outputs=["image","image"])
+#     interface.launch(share=True,debug=True)


### PR DESCRIPTION
This PR documents the changes I made to get Autogosling running on my local machine (Mac, M2 chip). Python 3.12

- Previous `/flask/requriements.txt` were for a linux machine, probably created using `conda list --export > requirements.txt`. I created a new `environment.yml` with the minimal dependencies. I also noticed that torch and gradio weren't actually being used to run model inference so I commented those out to further reduce dependencies. 
- The old instructions didn't mention how you need to run `yarn` in `/frontend` to install dependencies, so I added that to the instructions. 

## Notes 
- Why did I choose `environment.yml` instead of `requirements.txt`? It seems like `environment.yml` is the [recommended](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually) way to define conda dependencies in a file. 
- I did try using venv instead of conda but ran into issues pip installing `onnxruntime`, so I proceeded with conda. 
- Other conda related issues: I found that after activating the autogosling conda env, I was still getting missing module errors. Apparently my [pyenv](https://github.com/pyenv/pyenv) python shim was taking precedence over the conda env python. Once I deactivated the base conda env, then activated the autogosling conda env, it was fixed. But I had to try a bunch of things before discovering that. Typical python experience. 